### PR TITLE
Support inline math and display math with mitex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,12 +4,6 @@ version = 3
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
@@ -30,7 +24,7 @@ checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 name = "plugin"
 version = "0.0.0"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags",
  "itoa",
  "memchr",
  "pulldown-cmark",
@@ -48,11 +42,11 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.9.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a1a2f1f0a7ecff9c31abbe177637be0e97a0aef46cf8738ece09327985d998"
+checksum = "666f0f59e259aea2d72e6012290c09877a780935cc3c18b1ceded41f3890d59c"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "memchr",
  "unicase",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 bitflags = "2.4.1"
 itoa = "1.0.9"
 memchr = "2.6.4"
-pulldown-cmark = { version = "0.9.3", default-features = false }
+pulldown-cmark = { version = "0.12.1", default-features = false }
 wasm-minimal-protocol.git = "https://github.com/astrale-sharp/wasm-minimal-protocol"
 wasm-minimal-protocol.rev = "637508c184c7bfad7caadf109e2fa3871d99c57e"
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ render(
   markdown,
   smart-punctuation: true,
   blockquote: none,
+  mitex: none,
   h1-level: 1,
   raw-typst: true,
   scope: (:),
@@ -105,7 +106,7 @@ The parameters are as follows:
 	You can set this to `read("somefile.md")` to import an external markdown file;
 	see the
 	[documentation for the read function](https://typst.app/docs/reference/data-loading/read/).
-	- Accepted values: All strings.
+	- Accepted values: All strings or raw text.
 	- Required.
 
 - `smart-punctuation`:
@@ -136,6 +137,24 @@ The parameters are as follows:
 	<!--raw-typst
 	#(box.with(stroke: (left: 1pt + black), inset: (left: 5pt, y: 6pt)))[which displays like this.]
 	-->
+
+- `mitex`:
+  A `mitex` callback function to be used when math equation is encountered in the Markdown,
+  or `none` if math equation should be treated as normal text.
+  Because Typst does not support latex math equation natively,
+  the user must configure this.
+  - Accepted values: The `mitex` function imported from [mitex](https://typst.app/universe/package/mitex) package, or `none`.
+  - Default value: `none`.
+
+  For example, to render math equation as a Typst math block,
+  one can use:
+  ```typ
+  #import "@preview/mitex:0.2.4": mitex
+  #cmarker.render(`$\int_1^2 x \mathrm{d} x$`, mitex: mitex)
+  ```
+  <!--raw-typst
+  $integral_1^2 x dd x$
+  -->
 
 - `h1-level`:
 	The level that top-level headings in Markdown should get in Typst.
@@ -190,6 +209,7 @@ We support CommonMark with a couple extensions.
 - `*emphasis*` or `_emphasis_`: *emphasis*
 - `**strong**` or `__strong__`: **strong**
 - `~strikethrough~`: ~strikethrough~
+- `$x + y$` or `$$x + y$$`: math equation with [mitex](https://typst.app/universe/package/mitex) package.
 - `[links](https://example.org)`: [links](https://example.org/)
 - `### Headings`, where `#` is a top-level heading,
 	`##` a subheading, `###` a sub-subheading, etc
@@ -223,10 +243,10 @@ We support CommonMark with a couple extensions.
 -
 	```md
 	1. Ordered
-	1. Lists
+	2. Lists
 	```
-	1. Ordered
-	1. Lists
+	3. Ordered
+	4. Lists
 - `> blockquotes`, if the `blockquote` parameter is set.
 - Images: `![Some tiled hexagons](examples/hexagons.png)`, giving
 	![Some tiled hexagons](examples/hexagons.png)

--- a/README.md
+++ b/README.md
@@ -243,10 +243,10 @@ We support CommonMark with a couple extensions.
 -
 	```md
 	1. Ordered
-	2. Lists
+	1. Lists
 	```
-	3. Ordered
-	4. Lists
+	1. Ordered
+	1. Lists
 - `> blockquotes`, if the `blockquote` parameter is set.
 - Images: `![Some tiled hexagons](examples/hexagons.png)`, giving
 	![Some tiled hexagons](examples/hexagons.png)

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ render(
   markdown,
   smart-punctuation: true,
   blockquote: none,
-  mitex: none,
+  math: none,
   h1-level: 1,
   raw-typst: true,
   scope: (:),
@@ -106,7 +106,7 @@ The parameters are as follows:
 	You can set this to `read("somefile.md")` to import an external markdown file;
 	see the
 	[documentation for the read function](https://typst.app/docs/reference/data-loading/read/).
-	- Accepted values: All strings or raw text.
+	- Accepted values: All strings or raw text code block.
 	- Required.
 
 - `smart-punctuation`:
@@ -138,12 +138,12 @@ The parameters are as follows:
 	#(box.with(stroke: (left: 1pt + black), inset: (left: 5pt, y: 6pt)))[which displays like this.]
 	-->
 
-- `mitex`:
-  A `mitex` callback function to be used when math equation is encountered in the Markdown,
+- `math`:
+  A `math` callback function to be used when math equation is encountered in the Markdown,
   or `none` if math equation should be treated as normal text.
   Because Typst does not support latex math equation natively,
   the user must configure this.
-  - Accepted values: The `mitex` function imported from [mitex](https://typst.app/universe/package/mitex) package, or `none`.
+  - Accepted values: The `math` function with form `f(block: true, body)`, such as the `mitex` function imported from [mitex](https://typst.app/universe/package/mitex) package, or `none`.
   - Default value: `none`.
 
   For example, to render math equation as a Typst math block,

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The parameters are as follows:
   or `none` if math equation should be treated as normal text.
   Because Typst does not support latex math equation natively,
   the user must configure this.
-  - Accepted values: The `math` function with form `f(block: true, body)`, such as the `mitex` function imported from [mitex](https://typst.app/universe/package/mitex) package, or `none`.
+  - Accepted values: The `math` function with form `f(block: true, latex-text)`, such as the `mitex` function imported from [mitex](https://typst.app/universe/package/mitex) package, or `none`.
   - Default value: `none`.
 
   For example, to render math equation as a Typst math block,

--- a/examples/tests.md
+++ b/examples/tests.md
@@ -41,6 +41,14 @@ A horizontal rule:
 - unordered
 - list
 
+Inline math: $\int_1^2 x \mathrm{d} x$
+
+Display math:
+
+$$
+\int_1^2 x \mathrm{d} x
+$$
+
 	with this paragraph nested in the last list element
 
 We can escape things with backslashes:

--- a/examples/tests.typ
+++ b/examples/tests.typ
@@ -5,6 +5,6 @@
   read("tests.md"),
   blockquote: box.with(stroke: (left: 1pt + black), inset: (left: 5pt, y: 6pt)),
   raw-typst: true,
-  mitex: mitex,
+  math: mitex,
   show-source: false,
 )

--- a/examples/tests.typ
+++ b/examples/tests.typ
@@ -1,8 +1,10 @@
 #import "../lib.typ" as cmarker
+#import "@preview/mitex:0.2.4": mitex
 
 #cmarker.render(
   read("tests.md"),
   blockquote: box.with(stroke: (left: 1pt + black), inset: (left: 5pt, y: 6pt)),
   raw-typst: true,
+  mitex: mitex,
   show-source: false,
 )

--- a/lib.typ
+++ b/lib.typ
@@ -3,23 +3,41 @@
   markdown,
   smart-punctuation: true,
   blockquote: none,
+  mitex: none,
   h1-level: 1,
   raw-typst: true,
   scope: (:),
   show-source: false,
 ) = {
-  let options = 0;
-  if smart-punctuation { options += 0b00000001; }
-  if blockquote != none { options += 0b00000010; }
-  if raw-typst { options += 0b00000100; }
+  if type(markdown) == content and markdown.has("text") {
+    markdown = markdown.text
+  }
+  let options = 0
+  if smart-punctuation {
+    options += 0b00000001
+  }
+  if blockquote != none {
+    options += 0b00000010
+  }
+  if raw-typst {
+    options += 0b00000100
+  }
+  if mitex != none {
+    options += 0b00001000
+    scope += (inlinemath: mitex.with(block: false), displaymath: mitex.with(block: true))
+  }
   let rendered = str(_p.render(bytes(markdown), bytes((options, h1-level))))
   if show-source {
     raw(rendered, block: true, lang: "typ")
   } else {
-    eval(rendered, mode: "markup", scope: (
-      blockquote: blockquote,
-      image: (..args) => image(..args),
-      ..scope,
-    ))
+    eval(
+      rendered,
+      mode: "markup",
+      scope: (
+        blockquote: blockquote,
+        image: (..args) => image(..args),
+        ..scope,
+      ),
+    )
   }
 }

--- a/lib.typ
+++ b/lib.typ
@@ -3,7 +3,7 @@
   markdown,
   smart-punctuation: true,
   blockquote: none,
-  mitex: none,
+  math: none,
   h1-level: 1,
   raw-typst: true,
   scope: (:),
@@ -18,13 +18,14 @@
   }
   if blockquote != none {
     options += 0b00000010
+    scope += (blockquote: blockquote)
   }
   if raw-typst {
     options += 0b00000100
   }
-  if mitex != none {
+  if math != none {
     options += 0b00001000
-    scope += (inlinemath: mitex.with(block: false), displaymath: mitex.with(block: true))
+    scope += (inlinemath: math.with(block: false), displaymath: math.with(block: true))
   }
   let rendered = str(_p.render(bytes(markdown), bytes((options, h1-level))))
   if show-source {
@@ -34,7 +35,6 @@
       rendered,
       mode: "markup",
       scope: (
-        blockquote: blockquote,
         image: (..args) => image(..args),
         ..scope,
       ),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,16 +225,16 @@ fn inner(markdown: &str, options: Options, h1_level: u8) -> Result<Vec<u8>, Stri
 
             InlineMath(s) => {
                 // We use #inlinemath(`…`) for inline math
-                result.extend_from_slice(b"#inlinemath(````tex\n");
-                result.extend_from_slice(s.as_bytes());
-                result.extend_from_slice(b"\n````)");
+                result.extend_from_slice(b"#inlinemath(\"");
+                escape_string(s.as_bytes(), &mut result);
+                result.extend_from_slice(b"\")");
             }
 
             DisplayMath(s) => {
                 // We use #displaymath(`…`) for display math
-                result.extend_from_slice(b"#displaymath(````tex\n");
-                result.extend_from_slice(s.as_bytes());
-                result.extend_from_slice(b"\n````)");
+                result.extend_from_slice(b"#displaymath(\"");
+                escape_string(s.as_bytes(), &mut result);
+                result.extend_from_slice(b"\")");
             }
 
             SoftBreak => result.push(b' '),
@@ -394,19 +394,16 @@ mod tests {
 
     #[test]
     fn math() {
-        assert_eq!(with_math("$x$"), "#inlinemath(````tex\nx\n````)\n\n");
+        assert_eq!(with_math("$x$"), "#inlinemath(\"x\")\n\n");
         assert_eq!(
             with_math("$\\alpha + \\beta$"),
-            "#inlinemath(````tex\n\\alpha + \\beta\n````)\n\n"
+            "#inlinemath(\"\\\\alpha + \\\\beta\")\n\n"
         );
-        assert_eq!(with_math("$$x$$"), "#displaymath(````tex\nx\n````)\n\n");
-        assert_eq!(with_math("a$x$b"), "a#inlinemath(````tex\nx\n````)b\n\n");
+        assert_eq!(with_math("$$x$$"), "#displaymath(\"x\")\n\n");
+        assert_eq!(with_math("a$x$b"), "a#inlinemath(\"x\")b\n\n");
         assert_eq!(render_("a$x$b"), "a\\$x\\$b\n\n");
         assert_eq!(render_("a$$x$$b"), "a\\$\\$x\\$\\$b\n\n");
-        assert_eq!(
-            with_math("$$\nx\n$$"),
-            "#displaymath(````tex\n\nx\n\n````)\n\n"
-        );
+        assert_eq!(with_math("$$\nx\n$$"), "#displaymath(\"\nx\n\")\n\n");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,16 +225,16 @@ fn inner(markdown: &str, options: Options, h1_level: u8) -> Result<Vec<u8>, Stri
 
             InlineMath(s) => {
                 // We use #inlinemath(`…`) for inline math
-                result.extend_from_slice(b"#inlinemath(`");
+                result.extend_from_slice(b"#inlinemath(````tex\n");
                 result.extend_from_slice(s.as_bytes());
-                result.extend_from_slice(b"`)");
+                result.extend_from_slice(b"\n````)");
             }
 
             DisplayMath(s) => {
                 // We use #displaymath(`…`) for display math
-                result.extend_from_slice(b"#displaymath(`");
+                result.extend_from_slice(b"#displaymath(````tex\n");
                 result.extend_from_slice(s.as_bytes());
-                result.extend_from_slice(b"`)");
+                result.extend_from_slice(b"\n````)");
             }
 
             SoftBreak => result.push(b' '),
@@ -394,16 +394,19 @@ mod tests {
 
     #[test]
     fn math() {
-        assert_eq!(with_math("$x$"), "#inlinemath(`x`)\n\n");
+        assert_eq!(with_math("$x$"), "#inlinemath(````tex\nx\n````)\n\n");
         assert_eq!(
             with_math("$\\alpha + \\beta$"),
-            "#inlinemath(`\\alpha + \\beta`)\n\n"
+            "#inlinemath(````tex\n\\alpha + \\beta\n````)\n\n"
         );
-        assert_eq!(with_math("$$x$$"), "#displaymath(`x`)\n\n");
-        assert_eq!(with_math("a$x$b"), "a#inlinemath(`x`)b\n\n");
+        assert_eq!(with_math("$$x$$"), "#displaymath(````tex\nx\n````)\n\n");
+        assert_eq!(with_math("a$x$b"), "a#inlinemath(````tex\nx\n````)b\n\n");
         assert_eq!(render_("a$x$b"), "a\\$x\\$b\n\n");
         assert_eq!(render_("a$$x$$b"), "a\\$\\$x\\$\\$b\n\n");
-        assert_eq!(with_math("$$\nx\n$$"), "#displaymath(`\nx\n`)\n\n");
+        assert_eq!(
+            with_math("$$\nx\n$$"),
+            "#displaymath(````tex\n\nx\n\n````)\n\n"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,9 @@ bitflags! {
 
 #[wasm_func]
 fn render(markdown: &[u8], options: &[u8]) -> Result<Vec<u8>, String> {
-    let &[options, h1_level] = options else { panic!() };
+    let &[options, h1_level] = options else {
+        panic!()
+    };
     let options = Options::from_bits(options).unwrap();
     let markdown = str::from_utf8(markdown).unwrap();
     inner(markdown, options, h1_level)
@@ -33,38 +35,43 @@ fn inner(markdown: &str, options: Options, h1_level: u8) -> Result<Vec<u8>, Stri
     while let Some(event) = next_event.take().or_else(|| parser.next()) {
         use pulldown_cmark::CodeBlockKind;
         use pulldown_cmark::Event::*;
-        use pulldown_cmark::Tag::*;
+        use pulldown_cmark::{Tag, TagEnd};
         match event {
-            Start(Paragraph) => {}
-            End(Paragraph) => result.extend_from_slice(b"\n\n"),
+            Start(Tag::Paragraph) => {}
+            End(TagEnd::Paragraph) => result.extend_from_slice(b"\n\n"),
 
-            Start(Heading(level, _, _)) => {
+            Start(Tag::Heading {
+                level,
+                id: _,
+                classes: _,
+                attrs: _,
+            }) => {
                 result.push(b'\n');
                 let equal_signs = level as usize - 1 + usize::from(h1_level);
                 result.resize(result.len() + equal_signs, b'=');
                 result.push(b' ');
             }
-            End(Heading(_, _, _)) => result.extend_from_slice(b"\n"),
+            End(TagEnd::Heading(_)) => result.extend_from_slice(b"\n"),
 
-            Start(BlockQuote) => {
+            Start(Tag::BlockQuote(_)) => {
                 if options.contains(Options::BLOCKQUOTE) {
                     result.extend_from_slice(b"#blockquote[");
                 }
             }
-            End(BlockQuote) => {
+            End(TagEnd::BlockQuote(_)) => {
                 if options.contains(Options::BLOCKQUOTE) {
                     result.extend_from_slice(b"]\n\n");
                 }
             }
 
-            Start(Strikethrough) => {
+            Start(Tag::Strikethrough) => {
                 result.extend_from_slice(b"#strike[");
             }
-            End(Strikethrough) => {
+            End(TagEnd::Strikethrough) => {
                 result.extend_from_slice(b"]");
             }
 
-            Start(CodeBlock(kind)) => {
+            Start(Tag::CodeBlock(kind)) => {
                 result.extend_from_slice(b"#raw(block:true,");
                 if let CodeBlockKind::Fenced(lang) = kind {
                     if !lang.is_empty() {
@@ -77,15 +84,15 @@ fn inner(markdown: &str, options: Options, h1_level: u8) -> Result<Vec<u8>, Stri
                 loop {
                     match parser.next().unwrap() {
                         Text(text) => escape_string(text.as_bytes(), &mut result),
-                        End(CodeBlock(_)) => break,
+                        End(TagEnd::CodeBlock) => break,
                         other => return Err(format!("unexpected {other:?} in code block")),
                     }
                 }
                 result.extend_from_slice(b"\")\n");
             }
-            End(CodeBlock(_)) => unreachable!(),
+            End(TagEnd::CodeBlock) => unreachable!(),
 
-            Start(List(first)) => {
+            Start(Tag::List(first)) => {
                 if let Some(first) = first {
                     result.extend_from_slice(b"#enum(start:");
                     result.extend_from_slice(itoa::Buffer::new().format(first).as_bytes());
@@ -94,40 +101,69 @@ fn inner(markdown: &str, options: Options, h1_level: u8) -> Result<Vec<u8>, Stri
                     result.extend_from_slice(b"#list(");
                 }
             }
-            End(List(_)) => result.extend_from_slice(b")\n"),
-            Start(Item) => result.push(b'['),
-            End(Item) => result.extend_from_slice(b"],"),
+            End(TagEnd::List(_)) => result.extend_from_slice(b")\n"),
+            Start(Tag::Item) => result.push(b'['),
+            End(TagEnd::Item) => result.extend_from_slice(b"],"),
 
             // TODO: Tables
-            Start(Table(_)) => todo!(),
-            End(Table(_)) => todo!(),
-            Start(TableHead | TableRow | TableCell) => todo!(),
-            End(TableHead | TableRow | TableCell) => todo!(),
+            Start(Tag::Table(_)) => todo!(),
+            End(TagEnd::Table) => todo!(),
+            Start(Tag::TableHead | Tag::TableRow | Tag::TableCell) => todo!(),
+            End(TagEnd::TableHead | TagEnd::TableRow | TagEnd::TableCell) => todo!(),
 
-            Start(Emphasis) | End(Emphasis) => result.push(b'_'),
-            Start(Strong) | End(Strong) => result.push(b'*'),
+            Start(Tag::Emphasis) | End(TagEnd::Emphasis) => result.push(b'_'),
+            Start(Tag::Strong) | End(TagEnd::Strong) => result.push(b'*'),
 
-            Start(Link(_, destination, _)) => {
+            Start(Tag::Link {
+                link_type: _,
+                dest_url,
+                title: _,
+                id: _,
+            }) => {
                 result.extend_from_slice(b"#link(\"");
-                escape_string(destination.as_bytes(), &mut result);
+                escape_string(dest_url.as_bytes(), &mut result);
                 result.extend_from_slice(b"\")[");
             }
-            End(Link(_, _, _)) => result.push(b']'),
+            End(TagEnd::Link) => result.push(b']'),
 
-            Start(Image(_, path, _)) => {
+            Start(Tag::Image {
+                link_type: _,
+                dest_url,
+                title: _,
+                id: _,
+            }) => {
                 result.extend_from_slice(b"#image(\"");
-                escape_string(path.as_bytes(), &mut result);
+                escape_string(dest_url.as_bytes(), &mut result);
                 result.extend_from_slice(b"\",alt:\"");
                 loop {
                     match parser.next().unwrap() {
                         Text(text) => escape_string(text.as_bytes(), &mut result),
-                        End(Image(_, _, _)) => break,
+                        End(TagEnd::Image) => break,
                         other => return Err(format!("unexpected {other:?} in image alt text")),
                     }
                 }
                 result.extend_from_slice(b"\")");
             }
-            End(Image(_, _, _)) => unreachable!(),
+            End(TagEnd::Image) => unreachable!(),
+
+            Start(
+                Tag::FootnoteDefinition(_)
+                | Tag::DefinitionList
+                | Tag::DefinitionListDefinition
+                | Tag::DefinitionListTitle
+                | Tag::MetadataBlock(_),
+            ) => todo!(),
+
+            End(
+                TagEnd::FootnoteDefinition
+                | TagEnd::DefinitionList
+                | TagEnd::DefinitionListDefinition
+                | TagEnd::DefinitionListTitle
+                | TagEnd::MetadataBlock(_),
+            ) => todo!(),
+
+            Start(Tag::HtmlBlock) => {}
+            End(TagEnd::HtmlBlock) => {}
 
             Text(text) => escape_text(text.as_bytes(), &mut result),
 
@@ -138,18 +174,20 @@ fn inner(markdown: &str, options: Options, h1_level: u8) -> Result<Vec<u8>, Stri
             }
 
             // We can’t support HTML, so just obliterate it
-            Html(s) => {
+            Html(s) | InlineHtml(s) => {
                 let raw_typst_start = b"<!--raw-typst";
                 if memmem::find(s.as_bytes(), b"<!--typst-begin-exclude-->").is_some() {
                     let mut layers = 0;
                     for event in &mut parser {
                         match event {
-                            Html(s) => {
+                            Html(s) | InlineHtml(s) => {
                                 if memmem::find(s.as_bytes(), b"<!--typst-end-exclude-->").is_some()
                                 {
                                     break;
                                 }
                             }
+                            Start(Tag::HtmlBlock) => {}
+                            End(TagEnd::HtmlBlock) => {}
                             Start(_) => layers += 1,
                             End(_) if layers != 0 => layers -= 1,
                             End(_) => {
@@ -160,7 +198,8 @@ fn inner(markdown: &str, options: Options, h1_level: u8) -> Result<Vec<u8>, Stri
                         }
                     }
                 } else if !options.contains(Options::RAW_TYPST) {
-                    // Don’t allow injecting raw Typst code if the user disables it
+                    // Don’t allow injecting raw Typst code if the user disables
+                    // it
                 } else if let Some(i) = memmem::find(s.as_bytes(), raw_typst_start) {
                     let mut event = CowStr::Borrowed(&s[i + raw_typst_start.len()..]);
                     loop {
@@ -180,13 +219,19 @@ fn inner(markdown: &str, options: Options, h1_level: u8) -> Result<Vec<u8>, Stri
                 }
             }
 
+            InlineMath(_) => {
+                // We can’t support math, so just obliterate it
+            }
+
+            DisplayMath(_) => {
+                // We can’t support math, so just obliterate it
+            }
+
             SoftBreak => result.push(b' '),
             HardBreak => result.extend_from_slice(b"\\ "),
 
             Rule => result.extend_from_slice(b"#line(length:100%)\n"),
 
-            // Not possible, since we currently disable these features
-            Start(FootnoteDefinition(_)) | End(FootnoteDefinition(_)) => unreachable!(),
             FootnoteReference(_) => unreachable!(),
             TaskListMarker(_) => unreachable!(),
         }
@@ -247,7 +292,7 @@ mod tests {
     #[test]
     fn lines() {
         assert_eq!(render_("a\nb"), "a b\n\n");
-        assert_eq!(render_("a \nb"), "a  b\n\n");
+        assert_eq!(render_("a \nb"), "a b\n\n");
         assert_eq!(render_("a  \nb"), "a\\ b\n\n");
         assert_eq!(render_("a\n\nb"), "a\n\nb\n\n");
     }


### PR DESCRIPTION
Support inline math and display math with mitex.

I like the cmarker. If the cmarker can support math equation, I think it will be more usefule. Are you willing to merge the PR, and then release a new version?

Thanks!